### PR TITLE
Support receiving duplicates of non-local items

### DIFF
--- a/Scripts/APReceiver.lua
+++ b/Scripts/APReceiver.lua
@@ -4,6 +4,7 @@ function APReceiver(Ob)
         --used in apTableFill
         Ob.randoclassList = {}
         Ob.randonameList = {}
+        Ob.allowDuplicatesClassesSet = {}
         --used in checkReceivedList()
         Ob.numbersTable = {}
     end
@@ -1313,9 +1314,46 @@ function APReceiver(Ob)
             'AP Item 317',
             
         }
+
+        -- Classes where unlimited copies (the integer limits should never be reached) can be received from AP, even if
+        -- AP sends more than were placed in the multiworld. In some cases, receiving more than a certain number will
+        -- have no effect, but the items will still be received.
+        -- When receiving any other class of item via AP server cheat command, if there is a locally placed item with
+        -- the same name, that locally placed item should be collected instead. But, if the matching locally placed item
+        -- has already been collected, then the received item will be ignored.
+        local allowDuplicatesClasses = {
+            'global.collectibles.Marksmanship',
+            'global.collectibles.Firestarting',
+            'global.collectibles.Confusion',
+            'global.collectibles.Levitation',
+            'global.collectibles.Telekinesis',
+            'global.collectibles.Invisibility',
+            'global.collectibles.Clairvoyance',
+            'global.collectibles.Shield',
+            'Global.Collectibles.RandoAmmoUp',
+            'Global.Collectibles.RandoLivesUp',
+            'Global.Collectibles.RandoConfusionUp',
+            'global.collectibles.RandoPsiChallengeMarker',
+            'global.collectibles.RandoSuitcaseTag',
+            'global.collectibles.RandoPurseTag',
+            'global.collectibles.RandoHatboxTag',
+            'global.collectibles.RandoSteamertrunkTag',
+            'global.collectibles.RandoDufflebagTag',
+            'Global.Characters.Vault',
+            'global.collectibles.ArrowheadBundleSmall',
+            'global.collectibles.ArrowheadBundleMedium',
+            'global.collectibles.RandoPsiCard',
+        }
+        -- Convert the list into a dictionary that will be treated like a set.
+        local allowDuplicatesClassesSet = {}
+        for k, v in allowDuplicatesClasses do
+            allowDuplicatesClassesSet[v] = TRUE
+        end
+
         --write results to new tables
         self.randoclassList = classTable
         self.randonameList = nameTable
+        self.allowDuplicatesClassesSet = allowDuplicatesClassesSet
 
         --[[Print the index and value of each number in the table
         for k, v in self.randoclassList do
@@ -1392,21 +1430,92 @@ function APReceiver(Ob)
 
     function Ob:stateCheckSendToPlayer()
         -- loops through self.numbersTable to send items to player
+
+        -- Index of the last item that was received from AP.
+        local lastApIndex = Global.player.stats.APLastIndex
+
+        -- Special handling for Gloria's Theater candles to ensure that, if multiple non-local candles are received,
+        -- they cause both available candles to be received and no more.
+        local nonLocalCandlesReceived = 0
+        -- If an item in the sequence gets skipped somehow, only print the warning once per iteration of
+        -- `self.numbersTable`.
+        local printedDesyncWarning = FALSE
+        GamePrint("Current num received items: " .. lastApIndex)
         for k, v in self.numbersTable do
             if k ~= 'n' then
-                --convert value to a number
-                local index = tonumber(v)
-                -- match the value with the index of class and name from rando tables
-                local apClass = self.randoclassList[index]
-                local apName = self.randonameList[index]
-                if apClass ~= 'global.collectibles.RandoSuitcase' and apClass ~= 'global.collectibles.RandoPurse' and apClass ~= 'global.collectibles.RandoHatbox' and apClass ~= 'global.collectibles.RandoSteamertrunk' and apClass ~= 'global.collectibles.RandoDufflebag' then
-                    --check player save data for items already sent by AP, skip if already collected
-                    if Global.player.stats.APItem[apName] ~= 'collected' then
-                        -- send the item to the player
-                        self:getRandoItem(apClass, apName)
-                        -- pause so they don't all spawn at once
-                        self:sleep(1.2)
+                --split the line "apIndex,index,isNonLocal" into its parts
+                local split = {}
+                -- Match groups of characters that are not ",". For each matched group, call a function to insert
+                -- the matched group into `split`.
+                gsub(v, "([^,]+)", function(c) tinsert(%split, c) end)
+                --convert the values to numbers
+                local apIndex = tonumber(split[1])
+                local index = tonumber(split[2])
+                -- The item has been received from the multiworld and was not placed locally.
+                local isNonLocal = split[3] == "1"
+
+                -- Only receive the item if it's the next one in the sequence.
+                if apIndex == (lastApIndex + 1) then
+                    -- match the value with the index of class and name from rando tables
+                    local apClass = self.randoclassList[index]
+                    local apName = self.randonameList[index]
+
+                    -- Some items can have multiple copies that never cause locally placed items of the same class to be
+                    -- collected.
+                    local isNonLocalCopy = isNonLocal and self.allowDuplicatesClassesSet[apClass]
+
+                    -- Gloria's Theater candles are unique in that 2 can be received, but no more, so special handling
+                    -- is required.
+                    if isNonLocal and apClass == 'global.props.Candle' then
+                        -- Locally placed items with duplicates are placed starting from their first available ID, so
+                        -- if only 1 candle is placed locally, it is guaranteed to be 'Candle1'.
+                        -- We don't rely on checking `Global.player.stats.APItem['Candle2'] == 'collected'` because if
+                        -- two non-local candles are received in quick succession, it's possible that the first candle
+                        -- won't have been collected by the time the second candle is received.
+                        if nonLocalCandlesReceived == 0 then
+                            apName = 'Candle2'
+                            nonLocalCandlesReceived = 1
+                        else
+                            -- 'Candle2' has been received already, so if there is a remaining non-local candle it must
+                            -- be 'Candle1'. If extra candles are received, they will do nothing because 'Candle1' will
+                            -- already have been collected.
+                            apName = 'Candle1'
+                            nonLocalCandlesReceived = 2
+                        end
                     end
+
+                    if isNonLocalCopy then
+                        -- Prefix name with '_' so that it is easy to tell that the item is a non-local copy and so that
+                        -- it is easy to recover the real name if needed.
+                        apName = '_' .. apName
+                    end
+
+                    -- Ignore baggage, because those are always collected locally.
+                    if apClass ~= 'global.collectibles.RandoSuitcase' and apClass ~= 'global.collectibles.RandoPurse' and apClass ~= 'global.collectibles.RandoHatbox' and apClass ~= 'global.collectibles.RandoSteamertrunk' and apClass ~= 'global.collectibles.RandoDufflebag' then
+                        -- If the item is not a non-local copy, check player save data and skip if the item has already
+                        -- been collected.
+                        if isNonLocalCopy or Global.player.stats.APItem[apName] ~= 'collected' then
+                            -- send the item to the player
+                            self:getRandoItem(apClass, apName, isNonLocalCopy)
+                            -- pause so they don't all spawn at once
+                            self:sleep(1.2)
+                        end
+                    end
+
+                    -- Update the index of the last received item.
+                    lastApIndex = apIndex
+                    Global.player.stats.APLastIndex = apIndex
+
+                elseif apIndex > lastApIndex and not printedDesyncWarning then
+                    -- The client handles resyncing with AP if it receives items out of order, but even when the client
+                    -- writes all the lines into ItemsReceived.txt in the correct order, sometimes the iteration here
+                    -- skips a line for some reason.
+                    -- The lines in ItemsReceived.txt being out of order shouldn't happen, but just in-case they can in
+                    -- the future, we won't break the loop here and will instead continue looking for the correct next
+                    -- item.
+                    GamePrint("Warning: Possible desync. The next AP Index was expected to be " .. (lastApIndex + 1) ..
+                              ", but was actually " .. apIndex)
+                    printedDesyncWarning = TRUE
                 end
             end
         end
@@ -1415,12 +1524,27 @@ function APReceiver(Ob)
     end
 
     --Gives item to player
-    function Ob:getRandoItem(class, name)
+    function Ob:getRandoItem(class, name, isNonLocalCopy)
         -- check if the item currently exists
         local sentitem = nil
-        local existing_item = FindScriptObject(name)
+        -- The extra `1` argument seems to tell the game to not print a stacktrace when the object doesn't exist.
+        local existing_item = FindScriptObject(name, 1)
         if (not existing_item) then
             -- item doesn't exist, spawn a new one
+            sentitem = SpawnScript(class, name)
+        elseif isNonLocalCopy then
+            -- If multiple non-local items of the same type are spawned in a row, sometimes the previous one won't be
+            -- dead before we want to spawn another one, e.g. PSI Challenge Markers, so append a number to the end of
+            -- the name to make it unique.
+            -- None of the non-local copies of items use their name for anything, other than being marked as a non-local
+            -- copy by starting with "_", so modifying the name by appending to it is fine.
+            local i = 1
+            local orig_name = name
+            repeat
+                name = orig_name .. "_" .. tostring(i)
+                i = i + 1
+            until(FindScriptObject(name, 1) == nil)
+
             sentitem = SpawnScript(class, name)
         else
             -- item exists, move it onto the player    

--- a/Scripts/APReceiver.lua
+++ b/Scripts/APReceiver.lua
@@ -1469,10 +1469,10 @@ function APReceiver(Ob)
                     if isNonLocal and apClass == 'global.props.Candle' then
                         -- Locally placed items with duplicates are placed starting from their first available ID, so
                         -- if only 1 candle is placed locally, it is guaranteed to be 'Candle1'.
-                        -- We don't rely on checking `Global.player.stats.APItem['Candle2'] == 'collected'` because if
-                        -- two non-local candles are received in quick succession, it's possible that the first candle
-                        -- won't have been collected by the time the second candle is received.
-                        if nonLocalCandlesReceived == 0 then
+                        -- We don't rely on checking only `Global.player.stats.APItem['Candle2'] ~= 'collected'` because
+                        -- if two non-local candles are received in quick succession, it's possible that the first
+                        -- candle won't have been collected by the time the second candle is received.
+                        if nonLocalCandlesReceived == 0 and Global.player.stats.APItem['Candle2'] ~= 'collected' then
                             apName = 'Candle2'
                             nonLocalCandlesReceived = 1
                         else

--- a/Scripts/Dart.lua
+++ b/Scripts/Dart.lua
@@ -1078,7 +1078,7 @@ function Dart(Ob)
 			'ArrowheadBundleSmall', 'ArrowheadBundleMedium',
 			'CollectedVault', 'RandoPsiCard', 'RandoPsiMarker', 'RandoLivesUp', 'RandoAmmoUp', 'RandoProp', 'BrainJar',
 			--edit AP StatName
-			'APItem', 'APPlaceholder',
+			'APItem', 'APPlaceholder', 'APLastIndex',
 			}
 
 	--Called whenever the player saves their game
@@ -1197,7 +1197,10 @@ function Dart(Ob)
 			self.stats[statID] = {}
 		--edit adding all APPlaceholder Items as Table
 		elseif statID == 'APPlaceholder' then
-			self.stats[statID] = {}								
+			self.stats[statID] = {}
+		--edit adding last item index from Archipelago
+        elseif statID == 'APLastIndex' then
+            self.stats[statID] = -1
 		else
 			self.stats[statID] = 0
 		end
@@ -2820,55 +2823,66 @@ function Dart(Ob)
 	end
 
 -- ****************************************************************************
+--AP Collection Helper. Returns whether to write to item specific save data.
+    function Ob:genericAPCollect(name)
+        -- '_' prefix specifies that the item is a non-local copy received from the AP multiworld.
+        if strsub(name, 1, 1) == '_' then
+            GamePrint('Collected non-local copy ' .. name)
+            -- There should be no item that spawns in a level whose name matches this item.
+            return FALSE
+        else
+            self.stats.APItem[name] = 'collected'
+            -- Tell AP that the locally placed item has been collected from its location, sending an item out into the
+            -- multiworld if the item was an AP placeholder.
+            local apcollect = fso('APCollected', 'APCollected')
+		    apcollect:writeCollectedItem(name)
+		    GamePrint('Collected and stored local ' .. name)
+		    -- Item specific save data should be written to. This prevents the item from spawning again when loading the
+		    -- level again.
+		    return TRUE
+        end
+    end
+
+-- ****************************************************************************
 
 ------CUSTOM BAGGAGE TAG HANDLER------
 --Stores Collected BaggageTag, Global Key
 	function Ob:onCollectedSuitcaseTag(name,from)
-		self.stats.RandoSuitcaseTag[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoSuitcaseTag[name] = 'collected'
+        end
 		local value = 1
 		self.stats.CollectedSuitcaseTag = self.stats.CollectedSuitcaseTag + value
 	end
 
 	function Ob:onCollectedPurseTag(name,from)
-		self.stats.RandoPurseTag[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoPurseTag[name] = 'collected'
+        end
 		local value = 1
 		self.stats.CollectedPurseTag = self.stats.CollectedPurseTag + value
 	end
 
 	function Ob:onCollectedHatboxTag(name,from)
-		self.stats.RandoHatboxTag[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoHatboxTag[name] = 'collected'
+        end
 		local value = 1
 		self.stats.CollectedHatboxTag = self.stats.CollectedHatboxTag + value
 	end
 
 	function Ob:onCollectedSteamertrunkTag(name,from)
-		self.stats.RandoSteamertrunkTag[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoSteamertrunkTag[name] = 'collected'
+        end
 		local value = 1
 		self.stats.CollectedSteamertrunkTag = self.stats.CollectedSteamertrunkTag + value
 	end
 
 	function Ob:onCollectedDufflebagTag(name,from)
-		self.stats.RandoDufflebagTag[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoDufflebagTag[name] = 'collected'
+        end
 		local value = 1
 		self.stats.CollectedDufflebagTag = self.stats.CollectedDufflebagTag + value
 	end
@@ -2937,67 +2951,51 @@ function Dart(Ob)
 	------CUSTOM RANDOPSIPOWERS HANDLERS------
 	--Stores Collected RandoPsiPowers and Progressive Powerups
 	function Ob:onRandoClairvoyance(name,from)
-		self.stats.RandoClairvoyance[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoClairvoyance[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoConfusion(name,from)
-		self.stats.RandoConfusion[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoConfusion[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoFirestarting(name,from)
-		self.stats.RandoFirestarting[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoFirestarting[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoInvisibility(name,from)
-		self.stats.RandoInvisibility[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoInvisibility[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoLevitation(name,from)
-		self.stats.RandoLevitation[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoLevitation[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoMarksmanship(name,from)
-		self.stats.RandoMarksmanship[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoMarksmanship[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoShield(name,from)
-		self.stats.RandoShield[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoShield[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoTelekinesis(name,from)
-		self.stats.RandoTelekinesis[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoTelekinesis[name] = 'collected'
+        end
 	end
 
 -- ****************************************************************************
@@ -3005,11 +3003,9 @@ function Dart(Ob)
 	------CUSTOM RANDOPSICARD HANDLER------
 	--Stores Collected RandoPsiCard
 	function Ob:onRandoPsiCard(name,from)
-		self.stats.RandoPsiCard[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoPsiCard[name] = 'collected'
+        end
 	end
 
 -- ****************************************************************************
@@ -3017,11 +3013,9 @@ function Dart(Ob)
 	------CUSTOM RANDOPSIMARKER HANDLER------
 	--Stores Collected RandoPsiMarker
 	function Ob:onRandoPsiMarker(name,from)
-		self.stats.RandoPsiMarker[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoPsiMarker[name] = 'collected'
+        end
 	end
 
 -- ****************************************************************************
@@ -3043,11 +3037,10 @@ function Dart(Ob)
 	------CUSTOM VAULT HANDLER------
 	--Stores CollectedVault, Increases Rank when you open a vault
 	function Ob:onCollectedVault(name,from)
-		self.stats.CollectedVault[name] = 'collected'
-		self.stats.APItem[name] = 'collected' 
+	    if self:genericAPCollect(name) then
+		    self.stats.CollectedVault[name] = 'collected'
+        end
 		self.stats.totalVaults = self.stats.totalVaults+1
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
 
 		local seedsettings = fso('RandoSeed', 'Randoseed')
 		if seedsettings.lootboxvaults == TRUE then
@@ -3095,7 +3088,6 @@ function Dart(Ob)
 		else
 			self.rankMessage = "None..."
 		end
-		GamePrint('Stored '..name)
 		
 	end
 
@@ -3104,19 +3096,15 @@ function Dart(Ob)
 	------CUSTOM MAXLIVES AND MAXAMMO HANDLER------
 	--Stores RandoLivesUp and RandoAmmoUp
 	function Ob:onRandoLivesUp(name,from)
-		self.stats.RandoLivesUp[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoLivesUp[name] = 'collected'
+        end
 	end
 
 	function Ob:onRandoAmmoUp(name,from)
-		self.stats.RandoAmmoUp[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.RandoAmmoUp[name] = 'collected'
+        end
 	end
 
 -- ****************************************************************************
@@ -3124,19 +3112,15 @@ function Dart(Ob)
 	------CUSTOM ARROWHEADBUNDLE HANDLERS------
 	--Stores collected ArrowheadBundles
 	function Ob:onArrowheadBundleSmall(name,from)
-		self.stats.ArrowheadBundleSmall[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.ArrowheadBundleSmall[name] = 'collected'
+        end
 	end
 
 	function Ob:onArrowheadBundleMedium(name,from)
-		self.stats.ArrowheadBundleMedium[name] = 'collected'
-		self.stats.APItem[name] = 'collected'
-		local apcollect = fso('APCollected', 'APCollected')
-		apcollect:writeCollectedItem(name)
-		GamePrint('Stored '..name)
+	    if self:genericAPCollect(name) then
+		    self.stats.ArrowheadBundleMedium[name] = 'collected'
+        end
 	end
 
 -- ****************************************************************************

--- a/Scripts/Dart.lua
+++ b/Scripts/Dart.lua
@@ -1199,8 +1199,8 @@ function Dart(Ob)
 		elseif statID == 'APPlaceholder' then
 			self.stats[statID] = {}
 		--edit adding last item index from Archipelago
-        elseif statID == 'APLastIndex' then
-            self.stats[statID] = -1
+		elseif statID == 'APLastIndex' then
+			self.stats[statID] = -1
 		else
 			self.stats[statID] = 0
 		end
@@ -2824,65 +2824,65 @@ function Dart(Ob)
 
 -- ****************************************************************************
 --AP Collection Helper. Returns whether to write to item specific save data.
-    function Ob:genericAPCollect(name)
-        -- '_' prefix specifies that the item is a non-local copy received from the AP multiworld.
-        if strsub(name, 1, 1) == '_' then
-            GamePrint('Collected non-local copy ' .. name)
-            -- There should be no item that spawns in a level whose name matches this item.
-            return FALSE
-        else
-            self.stats.APItem[name] = 'collected'
-            -- Tell AP that the locally placed item has been collected from its location, sending an item out into the
-            -- multiworld if the item was an AP placeholder.
-            local apcollect = fso('APCollected', 'APCollected')
-		    apcollect:writeCollectedItem(name)
-		    GamePrint('Collected and stored local ' .. name)
-		    -- Item specific save data should be written to. This prevents the item from spawning again when loading the
-		    -- level again.
-		    return TRUE
-        end
-    end
+	function Ob:genericAPCollect(name)
+		-- '_' prefix specifies that the item is a non-local copy received from the AP multiworld.
+		if strsub(name, 1, 1) == '_' then
+			GamePrint('Collected non-local copy ' .. name)
+			-- There should be no item that spawns in a level whose name matches this item.
+			return FALSE
+		else
+			self.stats.APItem[name] = 'collected'
+			-- Tell AP that the locally placed item has been collected from its location, sending an item out into the
+			-- multiworld if the item was an AP placeholder.
+			local apcollect = fso('APCollected', 'APCollected')
+			apcollect:writeCollectedItem(name)
+			GamePrint('Collected and stored local ' .. name)
+			-- Item specific save data should be written to. This prevents the item from spawning again when loading the
+			-- level again.
+			return TRUE
+		end
+	end
 
 -- ****************************************************************************
 
 ------CUSTOM BAGGAGE TAG HANDLER------
 --Stores Collected BaggageTag, Global Key
 	function Ob:onCollectedSuitcaseTag(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoSuitcaseTag[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoSuitcaseTag[name] = 'collected'
+		end
 		local value = 1
 		self.stats.CollectedSuitcaseTag = self.stats.CollectedSuitcaseTag + value
 	end
 
 	function Ob:onCollectedPurseTag(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoPurseTag[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoPurseTag[name] = 'collected'
+		end
 		local value = 1
 		self.stats.CollectedPurseTag = self.stats.CollectedPurseTag + value
 	end
 
 	function Ob:onCollectedHatboxTag(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoHatboxTag[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoHatboxTag[name] = 'collected'
+		end
 		local value = 1
 		self.stats.CollectedHatboxTag = self.stats.CollectedHatboxTag + value
 	end
 
 	function Ob:onCollectedSteamertrunkTag(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoSteamertrunkTag[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoSteamertrunkTag[name] = 'collected'
+		end
 		local value = 1
 		self.stats.CollectedSteamertrunkTag = self.stats.CollectedSteamertrunkTag + value
 	end
 
 	function Ob:onCollectedDufflebagTag(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoDufflebagTag[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoDufflebagTag[name] = 'collected'
+		end
 		local value = 1
 		self.stats.CollectedDufflebagTag = self.stats.CollectedDufflebagTag + value
 	end
@@ -2951,51 +2951,51 @@ function Dart(Ob)
 	------CUSTOM RANDOPSIPOWERS HANDLERS------
 	--Stores Collected RandoPsiPowers and Progressive Powerups
 	function Ob:onRandoClairvoyance(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoClairvoyance[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoClairvoyance[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoConfusion(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoConfusion[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoConfusion[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoFirestarting(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoFirestarting[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoFirestarting[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoInvisibility(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoInvisibility[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoInvisibility[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoLevitation(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoLevitation[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoLevitation[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoMarksmanship(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoMarksmanship[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoMarksmanship[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoShield(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoShield[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoShield[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoTelekinesis(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoTelekinesis[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoTelekinesis[name] = 'collected'
+		end
 	end
 
 -- ****************************************************************************
@@ -3003,9 +3003,9 @@ function Dart(Ob)
 	------CUSTOM RANDOPSICARD HANDLER------
 	--Stores Collected RandoPsiCard
 	function Ob:onRandoPsiCard(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoPsiCard[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoPsiCard[name] = 'collected'
+		end
 	end
 
 -- ****************************************************************************
@@ -3013,9 +3013,9 @@ function Dart(Ob)
 	------CUSTOM RANDOPSIMARKER HANDLER------
 	--Stores Collected RandoPsiMarker
 	function Ob:onRandoPsiMarker(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoPsiMarker[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoPsiMarker[name] = 'collected'
+		end
 	end
 
 -- ****************************************************************************
@@ -3037,9 +3037,9 @@ function Dart(Ob)
 	------CUSTOM VAULT HANDLER------
 	--Stores CollectedVault, Increases Rank when you open a vault
 	function Ob:onCollectedVault(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.CollectedVault[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.CollectedVault[name] = 'collected'
+		end
 		self.stats.totalVaults = self.stats.totalVaults+1
 
 		local seedsettings = fso('RandoSeed', 'Randoseed')
@@ -3096,15 +3096,15 @@ function Dart(Ob)
 	------CUSTOM MAXLIVES AND MAXAMMO HANDLER------
 	--Stores RandoLivesUp and RandoAmmoUp
 	function Ob:onRandoLivesUp(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoLivesUp[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoLivesUp[name] = 'collected'
+		end
 	end
 
 	function Ob:onRandoAmmoUp(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.RandoAmmoUp[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.RandoAmmoUp[name] = 'collected'
+		end
 	end
 
 -- ****************************************************************************
@@ -3112,15 +3112,15 @@ function Dart(Ob)
 	------CUSTOM ARROWHEADBUNDLE HANDLERS------
 	--Stores collected ArrowheadBundles
 	function Ob:onArrowheadBundleSmall(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.ArrowheadBundleSmall[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.ArrowheadBundleSmall[name] = 'collected'
+		end
 	end
 
 	function Ob:onArrowheadBundleMedium(name,from)
-	    if self:genericAPCollect(name) then
-		    self.stats.ArrowheadBundleMedium[name] = 'collected'
-        end
+		if self:genericAPCollect(name) then
+			self.stats.ArrowheadBundleMedium[name] = 'collected'
+		end
 	end
 
 -- ****************************************************************************


### PR DESCRIPTION
The lines in ItemsReceived.txt are now comma separated and there are two additional columns.

The first new column is the item index from Archipelago which allows for games/clients to know the order that items have been received in or to request a resync with the server if some items are never received.

Using the item index to tell when an item is new is required because the received item IDs are no longer unique.

The second new column specifies whether the item has been received from a non-local source (a different world or from a cheat command).

When a non-local item is received, and it belongs to a class of items which allows for duplicates to be received, such as PsiCards, a new unique copy is created and given to the player without writing to save data that the item was received. Only the effect of receiving the item is written to save data.

When a non-local item is received, but it belongs to a class of items which does not allow for duplicates to be received, such as the Cobweb Duster, the non-local item is treated as if it was a locally received item instead. This means that if a Cobweb Duster is placed locally and a non-local Cobweb Duster is received, then the local Cobweb Duster will be collected too. Any extra Cobweb Duster items received after the first will then be ignored because the first received Cobweb Duster will have written to save data that it has been collected.

Gloria's Theater Candles are a special case because while multiple can be received, there is a limit of 2. Receiving a non-local Candle will treat the item as if it was locally received, but will prioritize "Candle2" first because it is the least likely to have been placed locally.

There are no changes to the behaviour of receiving local items.

The changes in this patch require similar changes to the AP client to write received items in the new format.

---

This PR requires the AP client changes in https://github.com/Akashortstack/Psychonauts_AP/pull/2