### PR TITLE
AP Folder Client Fix

### DIFF
--- a/Bugs.txt
+++ b/Bugs.txt
@@ -17,9 +17,6 @@ THINGS TO DO:
 
 --Give Brain Jars interestfx for more visibility?
 
---Milka's Brain Defaults to Vanilla location in Crow Basket if spawned in Asylum Lower Levels
-    --change location to require invis? work like vanilla game? Changes logic.
-
 --Cleanup Milkman
     --Make house items only spawn if entering the correct house
     --changes logic requirements, cobweb duster AND watering can

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Special Thanks To:
 
 Jill, for creating the Astralathe Mod loader that made this possible, as well as assisting me with coding questions and being an all around fantastic resource for information on the game.
 
+Mysteryem, for creating the Psychonauts Pop Tracker and contributing to the development of Psychonauts Archipelago.
+
 Roromaniac, for helping with more of my stupid coding questions and generally being a great resource and friend.
 
 Haalyle, for streaming, bug hunting, and giving feedback to motivate me to continue this project.

--- a/Scripts/APCollected.lua
+++ b/Scripts/APCollected.lua
@@ -8,15 +8,28 @@ function APCollected(Ob)
     --Prints item collected in RandoSeed.lua table formatting
     function Ob:writeCollectedItem(name)
         --get shuffled item table
+		local seedsettings = fso('RandoSeed', 'Randoseed')
         local referencelist = fso('ShuffleItems', 'ShuffleItems')
         local shufflednameslist = referencelist.randonameList
+
+        --find the matching seed folder in ModData
+        local folderName = seedsettings.APfoldername
+        local filePath = folderName.."/ItemsCollected.txt"
         --check the table for matching name, write its index
         for k, v in shufflednameslist do
             if name == v then
                 --write to text file for storage
-                local h = fopen("ItemsCollected.txt", "a")
-                fwrite(h, (k.."\n"))
-                fclose(h)
+                local h = fopen(filePath, "a")
+                -- Check if the file was opened successfully
+                if h then
+                    -- Write to the file
+                    fwrite(h, (k.."\n"))
+                    -- Close the file
+                    fclose(h)
+                else
+                    -- Handle the case where the file couldn't be opened
+                    GamePrint("Failed to open file for writing.")
+                end
                 return
             end
         end

--- a/Scripts/APReceiver.lua
+++ b/Scripts/APReceiver.lua
@@ -1446,7 +1446,8 @@ function APReceiver(Ob)
         -- If an item in the sequence gets skipped somehow, only print the warning once per iteration of
         -- `self.numbersTable`.
         local printedDesyncWarning = FALSE
-        GamePrint("Current num received items: " .. lastApIndex)
+        --used for debugging AP issues
+        --GamePrint("Current num received items: " .. lastApIndex)
         for k, v in self.numbersTable do
             if k ~= 'n' then
                 --split the line "apIndex,index,isNonLocal" into its parts

--- a/Scripts/APReceiver.lua
+++ b/Scripts/APReceiver.lua
@@ -1395,14 +1395,20 @@ function APReceiver(Ob)
         -- Create an empty table to store numbers
         self.numbersTable = {}
 
+        --find the matching seed folder in ModData
+        local seedsettings = fso('RandoSeed', 'Randoseed')
+        local folderName = seedsettings.APfoldername
+        local filePath = folderName.."/ItemsReceived.txt"
+
+        GamePrint(filePath)
+
         --read from ItemsReceived.txt for items sent by AP Client
-        local h = fopen("ItemsReceived.txt", "r")
+        local h = fopen(filePath, "r")
 
         -- function to fill table with numbers from ItemsReceived.txt
         local checkstuff = TRUE
         while checkstuff == TRUE do
             --Read a single line from the file (Lua 4 uses "*l" to read a line)
-            --each line should contain a single number
             local line = fread(h, "*l")
             --stop if line is blank
             if line == nil then

--- a/Scripts/APReceiver.lua
+++ b/Scripts/APReceiver.lua
@@ -1400,8 +1400,6 @@ function APReceiver(Ob)
         local folderName = seedsettings.APfoldername
         local filePath = folderName.."/ItemsReceived.txt"
 
-        GamePrint(filePath)
-
         --read from ItemsReceived.txt for items sent by AP Client
         local h = fopen(filePath, "r")
 
@@ -1412,12 +1410,10 @@ function APReceiver(Ob)
             local line = fread(h, "*l")
             --stop if line is blank
             if line == nil then
-                --GamePrint('End of List')
                 break
             else
                 --add number to table 
                 tinsert(self.numbersTable, line)        
-                --GamePrint(line)
             end
         end
 

--- a/Scripts/AS/Characters/TKBrainTank.lua
+++ b/Scripts/AS/Characters/TKBrainTank.lua
@@ -470,10 +470,13 @@ function TKBrainTank(Ob)
 		--edit write Victory if settings require it
 		Global:saveGlobal('bOleanderDefeated', 1)
 		local seedsettings = fso('RandoSeed', 'Randoseed')
+		--find the matching seed folder in ModData
+        local folderName = seedsettings.APfoldername
+        local filePath = folderName.."/victory.txt"
 		if seedsettings.beatoleander == TRUE and seedsettings.requireMC == FALSE then
 			if seedsettings.brainhunt == FALSE or (Global:loadGlobal('totalBrainsRedeemed') >= seedsettings.brainsrequired) then
 				--write to text file for client to read
-				local h = fopen("victory.txt", "w")
+				local h = fopen(filePath, "w")
 				fwrite(h, "victory\n")
 				fclose(h)
 			end

--- a/Scripts/AS/Props/AS_Bucket.lua
+++ b/Scripts/AS/Props/AS_Bucket.lua
@@ -1,0 +1,211 @@
+
+function AS_Bucket(Ob)
+-- constructor
+
+	if not Ob then
+		Ob = CreateObject('Global.Props.Geometry')
+		-- set up record keeping for crows, because they need to know when the bucket drops
+		Ob.iTotalCrows = 0
+		-- the speed with which the bucket crashes down
+		Ob.iSpeedDown = 3.5
+		-- the speed with which it goes up
+		Ob.iSpeedUp = 2							
+		-- the height it goes up from its placed position
+		Ob.iHeight = 1700
+		-- how much the bucket will quiver whenever a crow lands on it
+		Ob.iQuiverFactor = 10
+		-- how many crows there need to be on the bucket in order for it to go or stay down
+		Ob.iThreshold = 4
+		Ob.sCrowTrigger = nil	-- triggerSphere used to detect if the crows are on the jar.  Much safer than having them send us a message
+		
+		Ob.maxViewDistance = 350
+	end
+	
+
+	
+--  I N I T   F U N C T I O N S   A N D   S T A T E S  ********************************************
+
+	function Ob:onBeginLevel()
+        %Ob.Parent.onBeginLevel(self)
+		self:loadMesh('Levels/AS_Asylum/Props/AS_Bucket.plb')
+		SetEntityFlag(self, ENTITY_DRAWSHADOW, 1)
+		SetEntityCollideSphere(self, 70, 0, 90, 0)
+		SetPhysicsFlag(self, PHYSICS_COLLIDEE, 1)
+		SetPhysicsFlag(self, PHYSICS_COLLIDER, 1)
+		SetPhysicsFlag(self, PHYSICS_APPLYGRAVITY, 1)
+		SetSimulationCullDistance(self, 0)
+				
+		-- homebase position of the bucket
+		self.px, self.py, self.pz = self:getPosition()
+		
+		-- amount of crows needed before the bucket returns to the ground
+		self.iThreshold = 4
+		
+		-- to keep track of crows
+		self.tCrows = {}
+		
+	end
+	
+	function Ob:onPostBeginLevel()
+        %Ob.Parent.onPostBeginLevel(self)
+		--edit look for randomized item instead of Milka's Brain
+		self.Brain = FindScriptObject(self.randoitem,1)
+		if self.Brain then
+			--edit stop uncollected animations to allow attaching
+			if self.Brain.mover then
+				DetachEntityFromParent(self.Brain)
+				KillScript(self.Brain.mover)
+				self.Brain.mover = nil
+			end
+			--edit raise the Y value from 25 to make it easier to see
+			self.Brain:setPosition(self.px, self.py+75, self.pz)
+			SetMaxViewDistance(self.Brain, 0)
+			AttachEntityToEntity(self.Brain, self, 1)
+			SetEntityCollideIgnoreEntity(self, self.Brain, -1)
+			self:setEntityInterestLevel(kBRAIN_INTEREST)
+		end
+		
+	end
+
+--*************************************************************************************************
+
+	function Ob:beginStateDown()
+		SetPhysicsFlag(self, PHYSICS_COLLIDEE, 0)
+		if (self.Brain) then
+			SetPhysicsFlag(self.Brain, PHYSICS_COLLIDEE, 0)
+		end
+	end
+
+	function Ob:stateDown()
+		-- let the crows know to go down with the bucket
+		for i, v in self.tCrows do
+			self:sendMessage(v, 'BucketDown', '')
+		end
+		Yield()
+		-- move bucket down
+		--SetPhysicsFlag(self, PHYSICS_APPLYGRAVITY, 1)
+		self:moveToPos(self.px, self.py, self.pz, self.iSpeedDown)
+		-- let the crows know when done
+		for i, v in self.tCrows do
+			self:sendMessage(v, 'BucketDone', '')
+		end
+        
+		self:setState(nil)
+	end
+	
+	function Ob:endStateDown()
+		SetPhysicsFlag(self, PHYSICS_COLLIDER, 1)
+		if (self.Brain) then
+			SetPhysicsFlag(self.Brain, PHYSICS_COLLIDEE, 1)
+		end
+	end
+
+--*************************************************************************************************
+	
+	function Ob:beginStateUp()
+        SetPhysicsFlag(self, PHYSICS_COLLIDEE, 0)
+		if (self.Brain) then
+			SetPhysicsFlag(self.Brain, PHYSICS_COLLIDEE, 0)
+		end
+		self.bUp = nil
+	end
+	
+	function Ob:stateUp()
+		-- give the crows a chance to scatter
+		self:sleep(.6)
+		
+		-- let the crows know to go up with the bucket 
+		for i, v in self.tCrows do
+			v:onBucketUp()
+		end
+		-- move the bucket up
+		self:moveToPos(self.px, self.py + self.iHeight, self.pz, self.iSpeedUp)
+		SetPhysicsFlag(self, PHYSICS_APPLYGRAVITY, 0)
+		self.bDown = 0
+		
+		self:setState(nil)
+	end
+	
+	function Ob:endStateUp()
+        SetPhysicsFlag(self, PHYSICS_COLLIDEE, 1)
+		if (self.Brain) then
+			SetPhysicsFlag(self.Brain, PHYSICS_COLLIDEE, 1)
+		end
+		self.bUp = 1
+	end
+
+--*************************************************************************************************
+	
+	function Ob:stateQuiver()
+		local px, py, pz = self:getPosition()
+		if (self.py ~= py) then
+			self:moveToPos(px, py-self.iQuiverFactor, pz, .05)
+			self:moveToPos(px, py, pz, .1)
+		end
+		
+		self:setState(nil)
+	end
+	
+--  M E S S A G E   H A N D L E R S  **************************************************************
+
+	-- when a crow flies off, it sends a release msg
+	-- the bucket goes up only if iThreshold-1 or less crows left
+	function Ob:release(from)
+        if (not self.tCrows[from.Name].bTrapped or self.tCrows[from.Name].bTrapped == 1) then
+			self.iTotalCrows = self.iTotalCrows - 1
+		end
+		
+        self.tCrows[from.Name].bTrapped = 0
+		self.tCrows[from.Name].bDontFly = 0
+		
+		if (self.iTotalCrows < self.iThreshold) then
+			self:setState('Up')
+		end
+	end
+
+--*************************************************************************************************
+	
+	-- when a crow returns to the bucket, it sends a trap msg	
+	-- the bucket goes down only if there are iThreshold or more crows back
+	function Ob:trap(from)
+		self.tCrows[from.Name].bTrapped = 1
+		self.iTotalCrows = self.iTotalCrows + 1
+		self.tCrows[from.Name].bDontFly = 1
+		
+        if (self.iTotalCrows >= self.iThreshold) then
+			self:setState('Down')
+		else
+			self:setState('Quiver')
+		end
+	end
+
+--*************************************************************************************************
+	
+    function Ob:onItem(data, from)
+		if (GetPlayerInvisibility() == 1 and self.Brain) then
+            DetachEntityFromParent(self.Brain)
+			SetMaxViewDistance(self.Brain, 350)
+			SendMessage(self,self.Brain,'PickupBrain','','')
+			self.Brain = nil
+		end
+    end
+
+--  O T H E R  F U N C T I O N Z  ******************************************************************
+
+	function Ob:register(crow)
+		if (self.tCrows[crow.Name] == nil) then
+			self.tCrows[crow.Name] = crow 
+			self.iTotalCrows = self.iTotalCrows + 1
+			SetEntityCollideIgnoreEntity(self, self.tCrows[crow.Name], -1)
+			
+			-- set some things up for the crow
+			crow.iBucketHeight = self.iHeight
+			crow.iBucketSpeedUp = self.iSpeedUp
+			crow.iBucketSpeedDown = self.iSpeedDown
+		end
+	end
+--*************************************************************************************************
+
+	return Ob
+end
+

--- a/Scripts/CA/CABU.lua
+++ b/Scripts/CA/CABU.lua
@@ -361,23 +361,6 @@ function CABU(Ob)
 		%Ob.Parent.onBeginLevel(self)
 
 		self.playerDart = FindScriptObject( 'Dart' )
-
-		--edit clear ModData for a fresh start, creates files if they don't exist
-		local a = fopen("ItemsCollected.txt", "w")
-		fwrite(a, "")
-		fclose(a)
-
-		local b = fopen("ItemsReceived.txt", "w")
-		fwrite(b, "")
-		fclose(b)
-
-		local c = fopen("DeathlinkIn.txt", "w")
-		fwrite(c, "")
-		fclose(c)
-
-		local d = fopen("DeathlinkOut.txt", "w")
-		fwrite(d, "")
-		fclose(d)
 		
 		-- init the bunkhouse control handler
 		ActivateBunkControlHandler()

--- a/Scripts/Dart.lua
+++ b/Scripts/Dart.lua
@@ -3049,27 +3049,27 @@ function Dart(Ob)
 		if seedsettings.lootboxvaults == TRUE then
 			--Random Rewards! Loot Box!
 			--Random value of arrowheads to receive
-			self.randArrows = random (10, 100)
+			self.randArrows = random (10, 75)
 			--Roll some RNG for Jackpots/Ranks to recieve
 			self.jackpotArrows = random (1, 50)
 			self.jackpotRanks = random (1, 50)
 		else
-			--Make Result Static, One Rank and 50 Arrowheads
+			--Make Result Static, One Rank and 25 Arrowheads
 			self.randArrows = 25
 			self.jackpotArrows = 1
 			self.JackpotRanks = 26
 		end
 		
-		--2% chance for 500 arrowheads instead
+		--2% chance for 250 arrowheads instead
 		if self.jackpotArrows == 50 then
-			UI_AdjustCollectible('arrowhead', 500, self)
-			SendMessage(self, self, 'Arrowhead', 500)
-			self.arrowsMessage = "500!!"
-		--8% chance for 250 arrowheads instead
-		elseif self.jackpotArrows >= 46 then
 			UI_AdjustCollectible('arrowhead', 250, self)
 			SendMessage(self, self, 'Arrowhead', 250)
 			self.arrowsMessage = "250!!"
+		--8% chance for 100 arrowheads instead
+		elseif self.jackpotArrows >= 46 then
+			UI_AdjustCollectible('arrowhead', 100, self)
+			SendMessage(self, self, 'Arrowhead', 100)
+			self.arrowsMessage = "100!!"
 		else
 			UI_AdjustCollectible('arrowhead', self.randArrows, self)
 			SendMessage(self, self, 'Arrowhead', self.randArrows)

--- a/Scripts/Dart.lua
+++ b/Scripts/Dart.lua
@@ -2496,11 +2496,14 @@ function Dart(Ob)
 
 		-- edit check for Victory Condition
 		local seedsettings = fso('RandoSeed', 'Randoseed')
+		--find the matching seed folder in ModData
+        local folderName = seedsettings.APfoldername
+        local filePath = folderName.."/victory.txt"
 		if seedsettings.brainhunt == TRUE and seedsettings.requireMC == FALSE then
 			if seedsettings.beatoleander == FALSE or Global:loadGlobal('bOleanderDefeated') == 1 then
 				if self.stats.totalBrainsRedeemed >= seedsettings.brainsrequired then
 					--write to text file for client to read
-					local h = fopen("victory.txt", "w")
+					local h = fopen(filePath, "w")
 					fwrite(h, "victory\n")
 					fclose(h)
 				end

--- a/Scripts/Deathlink.lua
+++ b/Scripts/Deathlink.lua
@@ -26,8 +26,12 @@ function Deathlink(Ob)
         --wait so function isn't called constantly
         self:sleep(1.0)
 
+        --find the matching seed folder in ModData
+        local seedsettings = fso('RandoSeed', 'Randoseed')
+        local folderName = seedsettings.APfoldername
+        self.DeathlinkInfilePath = folderName.."/DeathlinkIn.txt"
         --read from DeathlinkIn.txt for deathlinks sent by client
-        local h = fopen("DeathlinkIn.txt", "r")
+        local h = fopen(self.DeathlinkInfilePath, "r")
 
         -- function to check for incoming deaths
         local checkstuff = TRUE
@@ -45,7 +49,7 @@ function Deathlink(Ob)
         fclose(h)
 
         --clear the file 
-        local h = fopen("DeathlinkIn.txt", "w")
+        local h = fopen(self.DeathlinkInfilePath, "w")
         fwrite(h, (""))
         fclose(h)
         self:setState('SendDeaths')
@@ -82,8 +86,13 @@ function Deathlink(Ob)
 
 
     function Ob:listenerDartDie()
+        --find the matching seed folder in ModData
+        local seedsettings = fso('RandoSeed', 'Randoseed')
+        local folderName = seedsettings.APfoldername
+        self.DeathlinkOutfilePath = folderName.."/DeathlinkOut.txt"
+
         --write to text file for storage
-        local h = fopen("DeathlinkOut.txt", "w")
+        local h = fopen(self.DeathlinkOutfilePath, "w")
         if self.deathCount == 0 then
             fwrite(h, ("Raz Died! Send Deathlink!\n"))
             GamePrint("Raz Died! Send Deathlink!")
@@ -92,8 +101,13 @@ function Deathlink(Ob)
     end
 
     function Ob:triggerDeathlink()
+        --find the matching seed folder in ModData
+        local seedsettings = fso('RandoSeed', 'Randoseed')
+        local folderName = seedsettings.APfoldername
+        self.DeathlinkOutfilePath = folderName.."/DeathlinkOut.txt"
+
         --write to text file for storage
-        local h = fopen("DeathlinkOut.txt", "w")
+        local h = fopen(self.DeathlinkOutfilePath, "w")
         if self.deathCount == 0 then
             fwrite(h, ("Raz Died! Send Deathlink!\n"))
             GamePrint("Raz Died! Send Deathlink!")

--- a/Scripts/Global/Props/PropSign.lua
+++ b/Scripts/Global/Props/PropSign.lua
@@ -13,7 +13,7 @@ function PropSign(Ob)
 		Ob.HeldRotZ = 0 -- Editable
 
 		--edit to make name appear in all levels. *STILL NEEDS LOCALIZATION*
-		Ob.displayName = "Sign"	--DIALOG=<<Sign>>
+		Ob.displayName = "Stop Sign"	--DIALOG=<<Stop Sign>>
 
 		Ob.pickupSpriteName = 'MM_Sign'
 		Ob.clutchAnim = 'Anims/DartNew/BodyParts/Hold_MM_Sign.jan' -- Editable

--- a/Scripts/MC/MCBB.lua
+++ b/Scripts/MC/MCBB.lua
@@ -309,8 +309,12 @@ end
 		elseif (nextPhase == 4) then
 			Global.cutsceneScript:runCutscene('PhaseTransition34a', 1)
 		elseif (nextPhase == 5) then
+			local seedsettings = fso('RandoSeed', 'Randoseed')
+			--find the matching seed folder in ModData
+			local folderName = seedsettings.APfoldername
+			local filePath = folderName.."/victory.txt"
 			--write to text file for client to read
-			local h = fopen("victory.txt", "w")
+			local h = fopen(filePath, "w")
 			fwrite(h, "victory\n")
 			fclose(h)
 			

--- a/Scripts/Positions.lua
+++ b/Scripts/Positions.lua
@@ -1361,8 +1361,9 @@ function Positions(Ob)
                 y = 208, 
                 z = 1586,
                 ox = 0,
-                oy = 0,
+                oy = 90,
                 oz = 0,
+                puzzle = 'bucket'
             },
             item143 = {        
                 levelName = 'ASCO',

--- a/Scripts/Randomizer.lua
+++ b/Scripts/Randomizer.lua
@@ -69,6 +69,12 @@ function Randomizer(Ob)
                 ref.huntItem = name
             end
 
+            --code for Crow Bucket puzzle in ASCO
+            if puzzle == 'bucket' then
+                local ref = FindScriptObject('AS_Bucket')
+                ref.randoitem = name
+            end 
+
             --[[code for RankUp checks, each level is separate
             Handled by RankUpPlacer, spawned in CAJA levelscript]]
             --Rank5

--- a/mod_boot.lua
+++ b/mod_boot.lua
@@ -33,11 +33,15 @@ function RandoPlacer()
 	--rando:placeRandoObject(class, name, x, y, z, ox, oy, oz)
 	--EX: rando:placeRandoObject('Global.Characters.Vault', 'Vault1', -5629, 4510, -13242, 0, 0, 0)
 
-	--check if seed folder in ModData exists. If not, create it
-	local folderName = seed.APfoldername
-	if direxists(folderName) ~= TRUE then
+	--check ModData for seed specific folder
+	local folderName = seed.APfoldername	
+	if direxists(folderName) then
+		--do nothing, Seed Folder exists already 
+	else
+		--create a new seed folder
+		GamePrint("Seed Folder not found, creating new folder.")
 		mkdirs(folderName)
-		--create required files 
+		--creates required files inside new folder
 		local a = fopen(folderName.."/ItemsCollected.txt", "w")
 		fwrite(a, "")
 		fclose(a)
@@ -55,7 +59,7 @@ function RandoPlacer()
 		fclose(d)
 	end
 
-	--AP Related Scripts
+	-- spawn AP Related Scripts
 	SpawnScript('APReceiver', 'APReceiver')
 	SpawnScript('APCollected', 'APCollected')
 	SpawnScript('Deathlink', 'Deathlink')

--- a/mod_boot.lua
+++ b/mod_boot.lua
@@ -33,10 +33,33 @@ function RandoPlacer()
 	--rando:placeRandoObject(class, name, x, y, z, ox, oy, oz)
 	--EX: rando:placeRandoObject('Global.Characters.Vault', 'Vault1', -5629, 4510, -13242, 0, 0, 0)
 
-	--AP Related Stuff
+	--check if seed folder in ModData exists. If not, create it
+	local folderName = seed.APfoldername
+	if direxists(folderName) ~= TRUE then
+		mkdirs(folderName)
+		--create required files 
+		local a = fopen(folderName.."/ItemsCollected.txt", "w")
+		fwrite(a, "")
+		fclose(a)
+
+		local b = fopen(folderName.."/ItemsReceived.txt", "w")
+		fwrite(b, "")
+		fclose(b)
+
+		local c = fopen(folderName.."/DeathlinkIn.txt", "w")
+		fwrite(c, "")
+		fclose(c)
+
+		local d = fopen(folderName.."/DeathlinkOut.txt", "w")
+		fwrite(d, "")
+		fclose(d)
+	end
+
+	--AP Related Scripts
 	SpawnScript('APReceiver', 'APReceiver')
 	SpawnScript('APCollected', 'APCollected')
 	SpawnScript('Deathlink', 'Deathlink')
+
 end
 
 add_hook('postbeginlevel', 'RandoCleanup')


### PR DESCRIPTION
Changes folder reading and writing methods for the Randomizer. Instead of always defaulting to ModData folder, now creates a specific folder inside of ModData based on the seed name. Prevents information from getting loaded between seeds, and allows Archipelago client to connect at any time.