### PR TITLE
Add Mental Cobweb Shuffle

### DIFF
--- a/Scripts/APCobwebShuffle.lua
+++ b/Scripts/APCobwebShuffle.lua
@@ -1,0 +1,84 @@
+-- There are currently 54 total.
+-- The names are created by concatenating the cobweb name with the level name
+local cobweb_names = {
+"Cobweb1BBA2", -- (BB Area 2 Cobweb) Trapeze Cobweb
+"Cobweb2BBA2", -- (BB Area 2 Cobweb) Tightrope Tutorial
+"Cobweb3BBA2", -- (BB Area 2 Cobweb) Grindrail Wall
+"Cobweb3BBLT", -- (BB Finale Cobweb) Bunny Room Door
+"Cobweb4BBLT", -- (BB Finale Cobweb) Tunnel of Logs End
+"Cobweb1SACU", -- (SA Main Cobweb) Arch Block Left
+"Cobweb2SACU", -- (SA Main Cobweb) Arch Block Right
+"Cobweb3SACU", -- (SA Main Cobweb) Back of Shoebox Tower
+"Cobweb4SACU", -- (SA Main Cobweb) Shoebox Tower
+"Cobweb5SACU", -- (SA Main Cobweb) Flame Tower Arch
+"Cobweb1MIFL", -- (MI Area 1 Cobweb) Intro Statue Corner
+"Cobweb2MIFL", -- (MI Area 1 Cobweb) Behind Pinball Ladder
+"Cobweb3MIFL", -- (MI Area 1 Cobweb) Grindrail Rings
+"Cobweb1MILL", -- (MI Finale Cobweb) Fan Room Entrance
+"Cobweb2MILL", -- (MI Finale Cobweb) Party Room Floor
+"Cobweb1NIMP", -- (BT Main Cobweb) Bathtub
+"Cobweb2NIMP", -- (BT Main Cobweb) Forest Path Thorns
+"Cobweb3NIMP", -- (BT Main Cobweb) Forest High Platform
+"Cobweb4NIMP", -- (BT Main Cobweb) Shadow Monster Meat
+"Cobweb5NIMP", -- (BT Main Cobweb) Thorn Tower Right
+"Cobweb1LOMA", -- (LO Main Cobweb) Skyscraper Before Dam
+"Cobweb2LOMA", -- (LO Main Cobweb) Skyscrapers Before Tunnel
+"Cobweb3LOMA", -- (LO Main Cobweb) Behind Lasers
+"Cobweb4LOMA", -- (LO Main Cobweb) End of Dam
+"Cobweb5LOMA", -- (LO Main Cobweb) Ground after Bridge
+"Cobweb2MMI1", -- (MM Neighborhood Cobweb) Third House
+"Cobweb3MMI1", -- (MM Neighborhood Cobweb) Post Office Lobby
+"Cobweb4MMI1", -- (MM Neighborhood Cobweb) Right House before Post Office
+"webbieMMI1", -- (MM Neighborhood Cobweb) Webbed Garage
+"Cobweb1MMI2", -- (MM Depository Cobweb) Book Depository
+"Cobweb1THMS", -- (TH Stage Cobweb) Backstage Corridor
+"Cobweb2THMS", -- (TH Stage Cobweb) Below Teleporter
+"Cobweb3THMS", -- (TH Stage Cobweb) Storage Room Left
+"Cobweb4THMS", -- (TH Stage Cobweb) In the Audience
+"Cobweb5THMS", -- (TH Stage Cobweb) Below the Critic
+"Cobweb6THMS", -- (TH Stage Cobweb) Behind Stage
+"Cobweb7THMS", -- (TH Stage Cobweb) Storage Room Right
+"Cobweb1WWMA", -- (WW Main Cobweb) Beneath Small Arch
+"Cobweb3WWMA", -- (WW Main Cobweb) Blacksmith's Right Building Window
+"Cobweb4WWMA", -- (WW Main Cobweb) Blacksmith's Left Building
+"Cobweb5WWMA", -- (WW Main Cobweb) Blacksmith's Right Building Roof
+"Cobweb6WWMA", -- (WW Main Cobweb) Carpenter's House
+"Cobweb7WWMA", -- (WW Main Cobweb) Fred's House Basement
+"Cobweb8WWMA", -- (WW Main Cobweb) Under the Guillotine
+"Cobweb1BVRB", -- (BV Streets Cobweb) Diego's House Grindrail
+"Cobweb2BVRB", -- (BV Streets Cobweb) Diego's House
+"Cobweb3BVRB", -- (BV Streets Cobweb) Sewer Shower Tunnel
+"Cobweb4BVRB", -- (BV Streets Cobweb) Above Queen of Hearts
+"Cobweb5BVRB", -- (BV Streets Cobweb) Sewer Before Gate
+"Cobweb6BVRB", -- (BV Streets Cobweb) Diego's House Fireplace
+"Cobweb7BVRB", -- (BV Streets Cobweb) Near Diego's House
+"Cobweb1MCTC", -- (MC Main Cobweb) Tunnel of Love Ollie Escort Exit
+"Cobweb2MCTC", -- (MC Main Cobweb) Entrance Hall 1
+"Cobweb3MCTC", -- (MC Main Cobweb) Entrance Hall 2
+}
+
+local start_id = 552
+cobweb_name_to_id = {}
+for i = 1, getn(cobweb_names) do
+    local name = cobweb_names[i]
+    cobweb_name_to_id[name] = start_id + i - 1
+end
+
+function APCobwebShuffle(Ob)
+    if ( not Ob ) then
+        Ob = CreateObject('ScriptBase')
+    end
+
+    function Ob:collectedCobweb(name)
+        local fullName = name .. Global.levelScript:getLevelName()
+        location_id = cobweb_name_to_id[fullName]
+        if location_id then
+            apcollected = fso('APCollected', 'APCollected')
+            apcollected:writeCollectedLocation(location_id)
+        else
+            GamePrint(fullName .. " is not a valid mental cobweb name")
+        end
+    end
+
+    return Ob
+end

--- a/Scripts/APDeepArrowheadShuffle.lua
+++ b/Scripts/APDeepArrowheadShuffle.lua
@@ -52,10 +52,10 @@ local mega_arrowhead_names = {
 }
 
 local start_id = 503
-location_to_id = {}
+mega_arrowhead_name_to_id = {}
 for i = 1, getn(mega_arrowhead_names) do
     local name = mega_arrowhead_names[i]
-    location_to_id[name] = start_id + i - 1
+    mega_arrowhead_name_to_id[name] = start_id + i - 1
 end
 
 
@@ -65,7 +65,7 @@ function APDeepArrowheadShuffle(Ob)
     end
 
     function Ob:collectedDeepArrowhead(name)
-        location_id = location_to_id[name]
+        location_id = mega_arrowhead_name_to_id[name]
         if location_id then
             apcollected = fso('APCollected', 'APCollected')
             apcollected:writeCollectedLocation(location_id)

--- a/Scripts/Dart.lua
+++ b/Scripts/Dart.lua
@@ -2764,7 +2764,15 @@ function Dart(Ob)
 	function Ob:onCollectedCobweb(value,from)
 		value = (value and tonumber(value)) or 1
 		self.stats.cobwebs = self.stats.cobwebs + value
-		self.stats.websInInv = self.stats.websInInv + value
+		-- Check if Cobweb Shuffle is enabled.
+		local settings = FindScriptObject('RandoSeed')
+		if settings.cobwebShuffle == TRUE then
+			-- Send an AP location check instead of adding a cobweb to the player's inventory.
+			local cobwebShuffle = fso('APCobwebShuffle', 'APCobwebShuffle')
+			cobwebShuffle:collectedCobweb(from.Name)
+		else
+			self.stats.websInInv = self.stats.websInInv + value
+		end
 		self.stats.cobwebsFromEntireLevel = self.stats.cobwebsFromEntireLevel + value
 
 		if self.stats.cobwebsFromEntireLevel == Global.cobwebsPerLevel[Global.levelScript:getLevelPrefix()] then

--- a/Scripts/RandoItemTables.lua
+++ b/Scripts/RandoItemTables.lua
@@ -165,15 +165,16 @@ AP_ITEM_COUNTS = {
     ['OlyMind'] = 1,
 
     --AP has 1 less PSI Card by default since it has the Squirrel Roast Dinner taking up a location
-    ['Card'] = 110,
+    --54 are added for the Cobweb Shuffle option
+    ['Card'] = 110 + 54,
     --AP Placeholders, one for each location that can place an item into the game world
     ['AP Item '] = 317,
     --Added for the Deep Arrowhead Shuffle option
     ['DowsingRod'] = 1,
     --29 are added for the Deep Arrowhead Shuffle option
-    ['AHSmall'] = 59,
+    ['AHSmall'] = 30 + 29,
     --20 are added for the Deep Arrowhead Shuffle option
-    ['AHMedium'] = 25,
+    ['AHMedium'] = 5 + 20,
 }
 
 function RandoItemTables(Ob)

--- a/mod_boot.lua
+++ b/mod_boot.lua
@@ -66,6 +66,7 @@ function RandoPlacer()
 	SpawnScript('APReceiver', 'APReceiver')
 	SpawnScript('APCollected', 'APCollected')
 	SpawnScript('APDeepArrowheadShuffle', 'APDeepArrowheadShuffle')
+	SpawnScript('APCobwebShuffle', 'APCobwebShuffle')
 	SpawnScript('Deathlink', 'Deathlink')
 
 end


### PR DESCRIPTION
Adds an option for collecting Mental Cobwebs to send an AP Location check instead of awarding the player a Mental Cobweb.

The location ID lookup table for Deep Arrowhead Shuffle has been renamed to avoid global variable name conflicts.